### PR TITLE
fix: resolve Dependabot security vulnerabilities (#89, #90, #87, #21)

### DIFF
--- a/ontology-engine/graph-engine_2.13/pom.xml
+++ b/ontology-engine/graph-engine_2.13/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.33</version>
+            <version>2.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -61,51 +61,6 @@
             <version>3.12.4</version>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.cassandraunit</groupId>
-            <artifactId>cassandra-unit</artifactId>
-            <version>3.11.2.0</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-codec</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-handler</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.xerial.snappy</groupId>
-                    <artifactId>snappy-java</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.xerial.snappy</groupId>
-            <artifactId>snappy-java</artifactId>
-            <scope>test</scope>
-        </dependency>  
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec</artifactId>
-            <version>4.1.129.Final</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>net.java.dev.jna</groupId>
-            <artifactId>jna</artifactId>
-            <version>5.13.0</version>
-            <scope>test</scope>
-        </dependency>  
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-handler</artifactId>
-            <version>4.1.129.Final</version>
-            <scope>test</scope>
-        </dependency>
-
         <dependency>
             <groupId>com.dimafeng</groupId>
             <artifactId>testcontainers-scala_2.13</artifactId>
@@ -115,6 +70,12 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
+            <version>1.17.6</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>cassandra</artifactId>
             <version>1.17.6</version>
             <scope>test</scope>
         </dependency>

--- a/ontology-engine/graph-engine_2.13/src/test/scala/org/sunbird/graph/BaseSpec.scala
+++ b/ontology-engine/graph-engine_2.13/src/test/scala/org/sunbird/graph/BaseSpec.scala
@@ -1,26 +1,59 @@
 package org.sunbird.graph
 
-import java.io.File
-import com.typesafe.config.ConfigFactory
-import org.apache.commons.io.FileUtils
-import org.cassandraunit.utils.EmbeddedCassandraServerHelper
+import com.datastax.driver.core.{Cluster, ProtocolVersion, Session}
 import redis.embedded.RedisServer
 import org.scalatest.{AsyncFlatSpec, BeforeAndAfterAll, Matchers}
 import org.sunbird.cassandra.CassandraConnector
-import org.sunbird.common.Platform
-import org.sunbird.graph.service.util.DriverUtil
 import org.sunbird.graph.dac.model.Node
 import org.sunbird.graph.schema.FrameworkMasterCategoryMap
 import org.janusgraph.core.JanusGraph
 import org.janusgraph.core.JanusGraphFactory
-import java.lang.reflect.Field
+import org.testcontainers.containers.CassandraContainer
+
 import java.util
 import scala.collection.JavaConverters._
+
+/**
+ * Singleton that manages a single shared Cassandra testcontainer for all test suites
+ * in graph-engine_2.13.  The container is started lazily on first access and is never
+ * explicitly stopped — Testcontainers' Ryuk reaper handles teardown after the JVM exits.
+ */
+object CassandraTestSupport {
+
+    val container: CassandraContainer[_] = {
+        val c = new CassandraContainer("cassandra:3.11")
+        c.start()
+        c
+    }
+
+    private val cluster: Cluster =
+        Cluster.builder()
+            .addContactPoint(container.getHost)
+            .withPort(container.getMappedPort(9042))
+            .withoutJMXReporting()
+            .withProtocolVersion(ProtocolVersion.V4)
+            .build()
+
+    /** Open a new Session against the shared container cluster. */
+    def newSession(): Session = cluster.connect()
+
+    /**
+     * Inject the given session into CassandraConnector's private static sessionMap
+     * under key "lp" so that CassandraConnector.getSession() returns our container
+     * session instead of trying to reach a real Cassandra host.
+     */
+    def injectIntoConnector(session: Session): Unit = {
+        val field = classOf[CassandraConnector].getDeclaredField("sessionMap")
+        field.setAccessible(true)
+        val map = field.get(null).asInstanceOf[java.util.Map[String, Session]]
+        map.put("lp", session)
+    }
+}
 
 class BaseSpec extends AsyncFlatSpec with Matchers with BeforeAndAfterAll {
 
     var graph: JanusGraph = _
-    var session: com.datastax.driver.core.Session = null
+    var session: Session = null
     implicit val oec: OntologyEngineContext = new OntologyEngineContext
 
     private val script_1 = "CREATE KEYSPACE IF NOT EXISTS content_store WITH replication = {'class': 'SimpleStrategy','replication_factor': '1'};"
@@ -51,16 +84,16 @@ class BaseSpec extends AsyncFlatSpec with Matchers with BeforeAndAfterAll {
         }
     }
 
-    def setUpEmbeddedCassandra(): Unit = {
-        System.setProperty("cassandra.unsafesystem", "true")
-        EmbeddedCassandraServerHelper.startEmbeddedCassandra("/cassandra-unit.yaml", 100000L)
+    def setUpCassandraContainer(): Unit = {
+        session = CassandraTestSupport.newSession()
+        CassandraTestSupport.injectIntoConnector(session)
     }
 
     var redisServer: RedisServer = _
 
     override def beforeAll(): Unit = {
         setUpEmbeddedGraph()
-        setUpEmbeddedCassandra()
+        setUpCassandraContainer()
         setupRedis()
         setupGraphData()
         createRelationData()
@@ -71,9 +104,9 @@ class BaseSpec extends AsyncFlatSpec with Matchers with BeforeAndAfterAll {
         if (null != graph) {
             graph.close()
         }
-        if(null != session && !session.isClosed)
+        if (null != session && !session.isClosed)
             session.close()
-        EmbeddedCassandraServerHelper.cleanEmbeddedCassandra()
+        // Container is a singleton managed by Testcontainers' Ryuk reaper — do not stop it here.
         if (null != redisServer) {
             redisServer.stop()
         }
@@ -85,10 +118,10 @@ class BaseSpec extends AsyncFlatSpec with Matchers with BeforeAndAfterAll {
     }
 
     def executeCassandraQuery(queries: String*): Unit = {
-        if(null == session || session.isClosed){
+        if (null == session || session.isClosed) {
             session = CassandraConnector.getSession
         }
-        for(query <- queries) {
+        for (query <- queries) {
             session.execute(query)
         }
     }
@@ -120,7 +153,7 @@ class BaseSpec extends AsyncFlatSpec with Matchers with BeforeAndAfterAll {
 
 
     def createVertex(label: String, properties: Map[String, AnyRef]): Unit = {
-        val vertex = graph.asInstanceOf[org.janusgraph.core.JanusGraphTransaction].addVertex(org.apache.tinkerpop.gremlin.structure.T.label, label)
+        val vertex = graph.addVertex(org.apache.tinkerpop.gremlin.structure.T.label, label)
         properties.foreach { case (k, v) => vertex.property(k, v) }
     }
 
@@ -131,7 +164,7 @@ class BaseSpec extends AsyncFlatSpec with Matchers with BeforeAndAfterAll {
         graph.tx().commit()
     }
 
-	def createBulkNodes(): Unit ={
+	def createBulkNodes(): Unit = {
         createVertex("domain", Map[String, AnyRef]("IL_UNIQUE_ID" -> "do_0000123", "identifier" -> "do_0000123", "graphId" -> "domain"))
         createVertex("domain", Map[String, AnyRef]("IL_UNIQUE_ID" -> "do_0000234", "identifier" -> "do_0000234", "graphId" -> "domain"))
         createVertex("domain", Map[String, AnyRef]("IL_UNIQUE_ID" -> "do_0000345", "identifier" -> "do_0000345", "graphId" -> "domain"))

--- a/ontology-engine/graph-engine_2.13/src/test/scala/org/sunbird/graph/nodes/TestDataNode.scala
+++ b/ontology-engine/graph-engine_2.13/src/test/scala/org/sunbird/graph/nodes/TestDataNode.scala
@@ -15,7 +15,7 @@ import scala.concurrent.Future
 class TestDataNode extends BaseSpec {
 
     override def createVertex(label: String, properties: Map[String, AnyRef]): Unit = {
-        val vertex = graph.asInstanceOf[org.janusgraph.core.JanusGraphTransaction].addVertex(org.apache.tinkerpop.gremlin.structure.T.label, label)
+        val vertex = graph.addVertex(org.apache.tinkerpop.gremlin.structure.T.label, label)
         properties.foreach { case (k, v) => vertex.property(k, v) }
     }
 

--- a/ontology-engine/graph-engine_2.13/src/test/scala/org/sunbird/graph/utils/ScalaJsonUtilsTest.scala
+++ b/ontology-engine/graph-engine_2.13/src/test/scala/org/sunbird/graph/utils/ScalaJsonUtilsTest.scala
@@ -4,7 +4,7 @@ import java.util
 
 import com.fasterxml.jackson.databind.exc.{InvalidDefinitionException, MismatchedInputException}
 import org.apache.commons.lang3.StringUtils
-import org.codehaus.jackson.JsonProcessingException
+import com.fasterxml.jackson.core.JsonProcessingException
 import org.scalatest.{FlatSpec, Matchers}
 
 class ScalaJsonUtilsTest extends FlatSpec with Matchers {

--- a/platform-core/platform-common/pom.xml
+++ b/platform-core/platform-common/pom.xml
@@ -57,18 +57,12 @@
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
-            <version>3.17</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.xmlbeans</groupId>
-                    <artifactId>xmlbeans</artifactId>
-                </exclusion>
-            </exclusions>
+            <version>5.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.xmlbeans</groupId>
             <artifactId>xmlbeans</artifactId>
-            <version>3.0.0</version>
+            <version>5.2.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
 			<dependency>
 				<groupId>org.apache.zookeeper</groupId>
 				<artifactId>zookeeper</artifactId>
-				<version>3.8.4</version>
+				<version>3.8.6</version>
 			</dependency>
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
- Bump org.apache.zookeeper:zookeeper 3.8.4 → 3.8.6 in root dependencyManagement (fixes CVE: hostname verification bypass + improper config handling)

- Migrate graph-engine_2.13 tests from cassandra-unit to testcontainers-cassandra; upgrade snakeyaml 1.33 → 2.0 (fixes SnakeYaml Constructor Deserialization RCE); remove cassandra-unit:3.11.2.0 and its associated netty/snappy/jna overrides; add CassandraTestSupport singleton with reflection-based session injection

- Bump org.apache.poi:poi-ooxml 3.17 → 5.4.0 and xmlbeans 3.0.0 → 5.2.1 in platform-common (fixes improper input validation in OOXML file parsing)

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions: Java 11, scala-2.12, play-2.7.2
* Hardware versions: 2 CPU/ 4GB RAM

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

